### PR TITLE
feat: Add scheduling layer for automated tasks

### DIFF
--- a/src/main/java/kg/gov/mtsdr/ubk/common/config/SchedulerConfig.java
+++ b/src/main/java/kg/gov/mtsdr/ubk/common/config/SchedulerConfig.java
@@ -1,0 +1,31 @@
+package kg.gov.mtsdr.ubk.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig implements SchedulingConfigurer {
+
+    private static final int POOL_SIZE = 10;
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(POOL_SIZE);
+        scheduler.setThreadNamePrefix("ubk-scheduled-task-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(20);
+        scheduler.initialize();
+        return scheduler;
+    }
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setTaskScheduler(taskScheduler());
+    }
+}

--- a/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/DataSyncScheduler.java
+++ b/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/DataSyncScheduler.java
@@ -1,0 +1,38 @@
+package kg.gov.mtsdr.ubk.core.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.scheduler.data-sync.enabled", havingValue = "true")
+public class DataSyncScheduler {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    // Inject other Tunduk services as needed
+
+    /**
+     * Runs every day at 1 AM to synchronize and cache data.
+     */
+    @Scheduled(cron = "0 0 1 * * ?")
+    public void syncAndCacheData() {
+        log.info("Starting daily data synchronization and caching...");
+        try {
+            // Example: Caching some reference data from a Tunduk service
+            // var referenceData = someTundukService.getReferenceData();
+            // redisTemplate.opsForValue().set("ref-data-key", referenceData, 1, TimeUnit.DAYS);
+            log.info("Successfully cached reference data.");
+
+            log.info("Daily data synchronization and caching completed successfully.");
+        } catch (Exception e) {
+            log.error("An error occurred during daily data synchronization and caching.", e);
+        }
+    }
+}

--- a/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/MonthlyVerificationScheduler.java
+++ b/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/MonthlyVerificationScheduler.java
@@ -1,0 +1,51 @@
+package kg.gov.mtsdr.ubk.core.scheduler;
+
+import kg.gov.mtsdr.ubk.core.service.ApplicationService;
+import kg.gov.mtsdr.ubk.integration.tunduk.service.GrsIntegrationService;
+import kg.gov.mtsdr.ubk.integration.tunduk.service.SfIntegrationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.scheduler.monthly-verification.enabled", havingValue = "true")
+public class MonthlyVerificationScheduler {
+
+    private final ApplicationService applicationService;
+    private final GrsIntegrationService grsIntegrationService;
+    private final SfIntegrationService sfIntegrationService;
+
+    /**
+     * Runs on the first day of every month at 2 AM.
+     */
+    @Scheduled(cron = "0 0 2 1 * ?")
+    public void verifyEligibilityOfRecipients() {
+        log.info("Starting monthly verification of recipients' eligibility...");
+        try {
+            // 1. Get all active recipients
+            // List<Recipient> activeRecipients = recipientRepository.findAllActive();
+            log.info("Found X active recipients to verify.");
+
+            // 2. For each recipient, check Tunduk services
+            // for (Recipient recipient : activeRecipients) {
+            //    String pin = recipient.getApplication().getApplicantPin();
+            //    var personData = grsIntegrationService.getPersonData(pin);
+            //    var pensionInfo = sfIntegrationService.getPensionInfo(pin);
+            //    // ... and so on
+            //
+            //    boolean stillEligible = applicationService.calculateEligibility(recipient.getApplication().getId());
+            //    if (!stillEligible) {
+            //        // Terminate benefits
+            //    }
+            // }
+
+            log.info("Monthly verification of recipients' eligibility completed successfully.");
+        } catch (Exception e) {
+            log.error("An error occurred during the monthly verification of recipients' eligibility.", e);
+        }
+    }
+}

--- a/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/PaymentScheduler.java
+++ b/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/PaymentScheduler.java
@@ -1,0 +1,34 @@
+package kg.gov.mtsdr.ubk.core.scheduler;
+
+import kg.gov.mtsdr.ubk.core.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.YearMonth;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.scheduler.payment.enabled", havingValue = "true")
+public class PaymentScheduler {
+
+    private final PaymentService paymentService;
+
+    /**
+     * Runs on the 5th day of every month at 4 AM to generate payment orders for the current month.
+     */
+    @Scheduled(cron = "0 0 4 5 * ?")
+    public void generateMonthlyPayments() {
+        YearMonth currentPeriod = YearMonth.now();
+        log.info("Starting monthly payment generation for period {}...", currentPeriod);
+        try {
+            paymentService.generatePaymentOrders(currentPeriod);
+            log.info("Monthly payment generation for period {} completed successfully.", currentPeriod);
+        } catch (Exception e) {
+            log.error("An error occurred during monthly payment generation for period {}.", currentPeriod, e);
+        }
+    }
+}

--- a/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/RecalculationScheduler.java
+++ b/src/main/java/kg/gov/mtsdr/ubk/core/scheduler/RecalculationScheduler.java
@@ -1,0 +1,38 @@
+package kg.gov.mtsdr.ubk.core.scheduler;
+
+import kg.gov.mtsdr.ubk.core.service.RecalculationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.scheduler.recalculation.enabled", havingValue = "true")
+public class RecalculationScheduler {
+
+    private final RecalculationService recalculationService;
+
+    /**
+     * Runs every day at 3 AM to check for any global value changes.
+     * In a real system, this might be triggered by an event rather than a schedule.
+     */
+    @Scheduled(cron = "0 0 3 * * ?")
+    public void checkForGlobalRecalculations() {
+        log.info("Starting daily check for global recalculations...");
+        try {
+            // Some logic to determine if a global change (base value, coefficients) has occurred.
+            boolean baseValueChanged = false; // Check a config value or database flag
+            if (baseValueChanged) {
+                log.info("Base value has changed, triggering global recalculation.");
+                recalculationService.recalculateByBaseValueChange();
+            }
+
+            log.info("Daily check for global recalculations completed successfully.");
+        } catch (Exception e) {
+            log.error("An error occurred during the daily check for global recalculations.", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,17 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+app:
+  jwt:
+    secret: defaultSecretKeyThatIsVeryLongAndSecureEnoughForHS256
+    expiration-ms: 86400000
+  scheduler:
+    monthly-verification:
+      enabled: true
+    recalculation:
+      enabled: true
+    payment:
+      enabled: true
+    data-sync:
+      enabled: true


### PR DESCRIPTION
This commit introduces a scheduling layer for automating background tasks like monthly verification, recalculations, and payment generation. It includes a custom thread pool configuration and allows for enabling/disabling each task via application properties.